### PR TITLE
add feature: endpoint to destroy plots and any associated plot_plants

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,8 @@ GEM
     minitest (5.16.3)
     msgpack (1.6.0)
     nio4r (2.5.8)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.9-x86_64-linux)
@@ -175,6 +177,7 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux
 
@@ -201,4 +204,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.27
+   2.3.20

--- a/app/controllers/api/v1/plots_controller.rb
+++ b/app/controllers/api/v1/plots_controller.rb
@@ -18,6 +18,7 @@ class Api::V1::PlotsController < ApplicationController
   def destroy
     plot = set_plot
     plot.destroy
+  end
 
   def create
     plot = @garden.plots.create(plot_params)
@@ -33,6 +34,7 @@ class Api::V1::PlotsController < ApplicationController
 
   def set_plot
     Plot.find(params[:id])
+  end
 
   def set_garden
     @garden = Garden.find(params[:garden_id])

--- a/app/controllers/api/v1/plots_controller.rb
+++ b/app/controllers/api/v1/plots_controller.rb
@@ -7,11 +7,22 @@ class Api::V1::PlotsController < ApplicationController
   end
 
   def show
-    plot = PlotSerializer.new(Plot.find(params[:id]))
+    plot = PlotSerializer.new(set_plot)
 
     # seperate plot plants controller
     # plot_plants = PlotPlantSerializer.new(plot.plot_plants)
     
     render json: plot
+  end
+
+  def destroy
+    plot = set_plot
+    plot.destroy
+  end
+
+  private
+
+  def set_plot
+    Plot.find(params[:id])
   end
 end

--- a/app/models/plot.rb
+++ b/app/models/plot.rb
@@ -1,6 +1,6 @@
 class Plot < ApplicationRecord
   belongs_to :garden
-  has_many :plot_plants
+  has_many :plot_plants, dependent: :destroy
   has_many :plants, through: :plot_plants
 
   validates_presence_of :name

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :gardens, only: %i(index) do
-        resources :plots, only: %i(index show)
+        resources :plots, only: %i(index show destroy)
       end
       resources :plants, only: %i[index]  
     end

--- a/spec/requests/plots/destroy_spec.rb
+++ b/spec/requests/plots/destroy_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'plot destroy' do
+  let!(:garden) { create :garden }
+  let!(:plot) { create :plot, garden: garden }
+  let!(:plants) { create_list(:plant, 3) }
+
+  describe 'DELETE /gardens/:garden_id/plots/:id' do
+    it 'deletes the relevant plot' do
+      delete "/api/v1/gardens/#{garden.id}/plots/#{plot.id}"
+
+      expect(response).to be_successful
+      expect(response).to have_http_status(204)
+      expect(response.body).to be_empty
+    end
+
+    it 'deletes any plot_plants in plot' do
+      plot.plants << plants
+
+      delete "/api/v1/gardens/#{garden.id}/plots/#{plot.id}"
+
+      expect(response).to be_successful
+      expect(response).to have_http_status(204)
+      expect(response.body).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
### User Story Implemented
#20 

### Describe Features Added/Changed
Added an endpoint to destroy plots. Dependent: :destroy set on plot_plants, so any plantings within a plot will be destroyed along with the plot itself.

### Describe Tests Added/Changed
Request spec written to test destruction of empty and populated plots.

### Checklist before requesting a review
- [x] Added features have thorough tests written for their functionality?
- [x] All Tests Passing?
