### PR TITLE
21 patch gardensgarden idplotsid add plants to plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,19 +330,19 @@ GET `/gardens/<garden_id>/plots/<plot_id>/plot_plants`
       "id": "3",
       "type": "plot_plant",
       "attributes": {
-        "plant_id": "15"
-        "plant_name": "Common Clover"
-        "quantity": 5
-        "date_planted": 2022/05/18
+        "plant_id": "15",
+        "plant_name": "Common Clover",
+        "quantity": 5,
+        "date_planted": 2022-05-18
       }
     },
     {
       "id": "4",
       "type": "plot_plant",
       "attributes": {
-        "plant_id": "185"
-        "plant_name": "Columbine"
-        "quantity": null
+        "plant_id": "185",
+        "plant_name": "Columbine",
+        "quantity": null,
         "date_planted": null
       }
     },
@@ -365,7 +365,7 @@ If a plant has null values for `quantity` and `date_planted` then it has been ad
 
 POST `/gardens`
 
-**Required JSON Body:**
+**Example Post Request JSON Body:**
 
 ```JSON
 {
@@ -386,7 +386,7 @@ Response should match a GET `gardens/<garden_id>` response for the newly created
 
 POST `/gardens/<garden_id>/plots`
 
-**Required JSON Body:**
+**Example Post Request JSON Body:**
 
 ```JSON
 {
@@ -420,13 +420,21 @@ Will return status 204 with no JSON response if the plot was successfully delete
 
 ---
 
+### **Delete a plant from a plot**
+
+DELETE `/gardens/<garden_id>/plots/<plot_id>/plot_plants/<plot_plant_id>`
+
+**Notes:**
+
+Will return status 204 with no JSON response if the plot_plant was successfully deleted.
+
+---
+
 ### **Add plants to existing plot / update plot**
 
 PATCH `/gardens/<garden_id>/plots/<plot_id>`
 
-!!! _**This endpoint is subject to change depending on figuring out how this actually gets implemented**_
-
-**Example JSON Body:**
+**Example Patch Request JSON Body:**
 
 ```JSON
 {
@@ -441,3 +449,41 @@ The response should match a GET `/gardens/<garden_id>/plots/<plot_id>` request r
 **Notes:**
 
 The intension of this endpoint is to add plants to a plot, but it could also be passed a "name" in the JSON body to update the name.
+
+---
+
+### **Update a plot plant (plant the plant)**
+
+PATCH `gardens/<garden_id>/plots/<plot_id>/plot_plants/<plot_plant_id>`
+
+**Exampe Patch Request JSON Body:**
+
+```JSON
+{
+  "date_planted": 2022-05-13,
+  "quantity": 15
+}
+```
+
+**Example Response**
+
+```JSON
+{
+  "data": {
+    "id": "15",
+    "type": "plot plant",
+    "attributes": {
+      "quantity": 15,
+      "date_planted": 2022-05-15,
+      "plant_id": 85,
+      "plant_name": "Wild Thornbush"
+    }
+  }
+}
+```
+
+**Notes:**
+
+This endpoint is intended to be used to record the _planting_ of a plant in a garden after it has been added through the plant discover page.
+
+---

--- a/app/controllers/api/v1/plots_controller.rb
+++ b/app/controllers/api/v1/plots_controller.rb
@@ -15,13 +15,23 @@ class Api::V1::PlotsController < ApplicationController
     render json: plot
   end
 
+  def update
+    plot = Plot.find(params[:id])
+    if plot.update(plot_params)
+      render json: PlotSerializer.new(plot)
+    else
+      errors = ErrorSerializer.new(plot.errors)
+      render rson: errors.show, status: 400
+    end
+  end
+
   def destroy
     plot = set_plot
     plot.destroy
   end
 
   def create
-    plot = @garden.plots.create(plot_params)
+    plot = @garden.plots.new(plot_params)
     if plot.save
       render json: PlotSerializer.new(plot), status: 201
     else
@@ -41,6 +51,6 @@ class Api::V1::PlotsController < ApplicationController
   end
 
   def plot_params
-    params.permit(:name)
+    params.require(:plot).permit(:name, plant_ids: [])
   end
 end

--- a/app/controllers/concerns/exception_handler.rb
+++ b/app/controllers/concerns/exception_handler.rb
@@ -9,5 +9,9 @@ module ExceptionHandler
     rescue_from ActiveRecord::RecordInvalid do |e|
       json_response({ message: e.message }, :unprocessable_entity)
     end
+
+    rescue_from ActionController::ParameterMissing do |e|
+      json_response({ message: e.message }, :bad_request)
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       resources :gardens, only: %i(index show) do
-        resources :plots, only: %i(index show create destroy)
+        resources :plots, only: %i(index show create update destroy)
       end
       resources :plants, only: %i[index show]  
     end

--- a/spec/requests/api/v1/plots/update_spec.rb
+++ b/spec/requests/api/v1/plots/update_spec.rb
@@ -1,0 +1,55 @@
+require 'rails_helper'
+
+RSpec.describe 'plots#update' do
+  describe 'when a PATCH request is sent to /gardens/:garden_id/plots' do
+    let!(:garden) { create(:garden) }
+    let!(:plot) { create(:plot, garden: garden) }
+    let!(:plants) { create_list(:plant, 20) }
+    let!(:headers) { {"CONTENT_TYPE" => "application/json"} }
+
+    describe 'happy path' do
+      let!(:http_body) { { plant_ids: [plants[5].id, plants[12].id]} }
+
+      it 'can add plants to a plot' do
+        patch "/api/v1/gardens/#{garden.id}/plots/#{plot.id}", headers: headers, params: JSON.generate(plot: http_body)
+
+        expect(response).to be_successful
+        expect(response).to have_http_status(200)
+
+        result = JSON.parse(response.body, symbolize_names: true)
+
+        expect(result).to have_key(:data)
+
+        data = result[:data]
+        expect(data[:id]).to eq(plot.id.to_s)
+        expect(data[:type]).to eq("plot")
+        expect(data).to have_key(:attributes)
+
+        attributes = data[:attributes]
+        expect(attributes).to have_key(:name)
+        expect(attributes[:name]).to eq(plot.name)
+
+        plot.reload
+        expect(plot.plants).to eq([plants[5], plants[12]])
+      end
+    end
+
+    describe 'sad path' do
+      describe 'if plant id does not exist' do
+        let!(:http_body) { { plant_ids: [plants[5].id, 6516516]} }
+
+        it 'returns a 400 error with information' do
+          patch "/api/v1/gardens/#{garden.id}/plots/#{plot.id}", headers: headers, params: JSON.generate(plot: http_body)
+
+          expect(response).not_to be_successful
+          expect(response).to have_http_status(404)
+
+          result = JSON.parse(response.body, symbolize_names: true)
+          
+          expect(result).to have_key(:message)
+          expect(result[:message]).to eq("Couldn't find all Plants with 'id': (#{plants[5].id}, 6516516) (found 1 results, but was looking for 2). Couldn't find Plant with id 6516516.")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
### User Story Implemented
#21 
### Describe Features Added/Changed
The FE can now send a PATCH request to a plot with an array of plant_ids in order to add those plants to the plot.
### Describe Tests Added/Changed
Tested happy and sad path for an update. Also implemented change to how the udpate and create methods receive paramters for a POST or PATCH request, so I updated the tests for plot #create to reflect new method.

### Checklist before requesting a review
- [x] Added features have thorough tests written for their functionality?
- [x] All Tests Passing?
