### PR TITLE
13 get plantsstate=xxsearch name=search20query

### DIFF
--- a/app/controllers/api/v1/gardens_controller.rb
+++ b/app/controllers/api/v1/gardens_controller.rb
@@ -1,11 +1,22 @@
 class Api::V1::GardensController < ApplicationController
+  before_action :set_garden, only: %i(show destroy)
+  
   def index
     gardens = Garden.where(user_id: params[:user_id])
     render json: GardenSerializer.new(gardens)
   end
   
   def show
-    garden = Garden.find(params[:id])
-    render json: GardenSerializer.new(garden, params: {weather: true})
+    render json: GardenSerializer.new(@garden, params: {weather: true})
+  end
+
+  def destroy
+    @garden.destroy
+  end
+
+  private
+
+  def set_garden
+    @garden = Garden.find(params[:id])
   end
 end

--- a/app/controllers/api/v1/gardens_controller.rb
+++ b/app/controllers/api/v1/gardens_controller.rb
@@ -10,16 +10,6 @@ class Api::V1::GardensController < ApplicationController
     render json: GardenSerializer.new(@garden, params: {weather: true})
   end
 
-  def destroy
-    @garden.destroy
-  end
-
-  private
-
-  def set_garden
-    @garden = Garden.find(params[:id])
-  end
-
   def create
     garden = Garden.new(garden_params)
     if garden.save
@@ -30,8 +20,16 @@ class Api::V1::GardensController < ApplicationController
     end
   end
 
+  def destroy
+    @garden.destroy
+  end
+  
   private
 
+  def set_garden
+    @garden = Garden.find(params[:id])
+  end
+  
   def garden_params
     params.require(:garden).permit(:user_id, :zip_code, :name, :state_code)
   end

--- a/app/controllers/api/v1/plants_controller.rb
+++ b/app/controllers/api/v1/plants_controller.rb
@@ -1,9 +1,14 @@
 class Api::V1::PlantsController < ApplicationController
   before_action :set_plant, only: [:show]
+  before_action :set_params
+
   def index
     if valid_params?
-      native_plants = PlantSerializer.new(Plant.native_to(params[:state]))
-      render json: native_plants
+      native_plants = Plant.native_to(params[:state_code])
+      if @search_name.present? || !@search_name.blank?
+        native_plants = native_plants.search_name(@search_name, @state_code)
+      end
+      render json: PlantSerializer.new(native_plants)
     end
   end
 
@@ -16,10 +21,10 @@ class Api::V1::PlantsController < ApplicationController
   def set_params
     @state_code = params[:state_code]
     @zip_code = params[:zip_code]
+    @search_name = params[:search_name]
   end
 
   def valid_params?
-    set_params
     if check(@state_code) && check(@zip_code)
       true
     elsif check(@state_code) && !check(@zip_code)

--- a/app/controllers/api/v1/plants_controller.rb
+++ b/app/controllers/api/v1/plants_controller.rb
@@ -14,24 +14,24 @@ class Api::V1::PlantsController < ApplicationController
   private
 
   def set_params
-    @state = params[:state]
+    @state_code = params[:state_code]
     @zip_code = params[:zip_code]
   end
 
   def valid_params?
     set_params
-    if check(@state) && check(@zip_code)
+    if check(@state_code) && check(@zip_code)
       true
-    elsif check(@state) && !check(@zip_code)
+    elsif check(@state_code) && !check(@zip_code)
       error = ErrorSerializer.new( {zip_code: "must be present"} )
       render json: error.custom_show, status: 400
       false
-    elsif check(@zip_code) && !check(@state)
-      error = ErrorSerializer.new( {state: "must be present"} )
+    elsif check(@zip_code) && !check(@state_code)
+      error = ErrorSerializer.new( {state_code: "must be present"} )
       render json: error.custom_show, status: 400
       false
     else
-      error = ErrorSerializer.new( {state: "must be present", zip_code: "must be present"} )
+      error = ErrorSerializer.new( {state_code: "must be present", zip_code: "must be present"} )
       render json: error.custom_show, status: 400
       false
     end

--- a/app/controllers/api/v1/plots_controller.rb
+++ b/app/controllers/api/v1/plots_controller.rb
@@ -1,5 +1,6 @@
 class Api::V1::PlotsController < ApplicationController
   before_action :set_garden, only: %i[index create]
+  before_action :set_plot, only: %i[show update destroy]
 
   def index
     plots = PlotSerializer.new(@garden.plots)
@@ -7,27 +8,20 @@ class Api::V1::PlotsController < ApplicationController
   end
 
   def show
-    plot = PlotSerializer.new(set_plot)
-
-    # seperate plot plants controller
-    # plot_plants = PlotPlantSerializer.new(plot.plot_plants)
-    
-    render json: plot
+    render json: PlotSerializer.new(@plot)
   end
 
   def update
-    plot = Plot.find(params[:id])
-    if plot.update(plot_params)
-      render json: PlotSerializer.new(plot)
+    if @plot.update(plot_params)
+      render json: PlotSerializer.new(@plot)
     else
-      errors = ErrorSerializer.new(plot.errors)
+      errors = ErrorSerializer.new(@plot.errors)
       render rson: errors.show, status: 400
     end
   end
 
   def destroy
-    plot = set_plot
-    plot.destroy
+    @plot.destroy
   end
 
   def create
@@ -43,7 +37,7 @@ class Api::V1::PlotsController < ApplicationController
   private
 
   def set_plot
-    Plot.find(params[:id])
+    @plot = Plot.find(params[:id])
   end
 
   def set_garden

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -1,17 +1,4 @@
-class Plant < ApplicationRecord
-  
-  # validations may not be necessary as we're seeding this data rather than relying on user input
-  validates_presence_of %i[
-    usda_symbol 
-    scientific_name 
-    common_name 
-    states
-    moisture_use
-    temperature_min
-  ]
-  
-  validates_numericality_of :temperature_min
-  
+class Plant < ApplicationRecord  
   has_many :plot_plants
   has_many :plots, through: :plot_plants
   
@@ -19,19 +6,3 @@ class Plant < ApplicationRecord
     where('states like ?', "%#{state}%")
   end
 end
-
-# other attributes that may/may not have data: 
-
-# drought_tolerance
-# fire_tolerance
-# toxicity
-# duration
-# growth_rate
-# salinity_tolerance
-# shade_tolerance
-# ph_minimum
-# ph_maximum
-# frost_free_days_min
-# precipitation_min
-# precipitation_max
-# temperature_min 

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -3,6 +3,10 @@ class Plant < ApplicationRecord
   has_many :plots, through: :plot_plants
   
   def self.native_to(state)
-    where('states like ?', "%#{state}%")
+    where('states ilike ?', "%#{state}%")
+  end
+
+  def self.search_name(name, state)
+    native_to(state).where('common_name ilike ? OR scientific_name ilike ?', "%#{name}%", "%#{name}%")
   end
 end

--- a/app/models/plant.rb
+++ b/app/models/plant.rb
@@ -2,11 +2,11 @@ class Plant < ApplicationRecord
   has_many :plot_plants
   has_many :plots, through: :plot_plants
   
-  def self.native_to(state)
-    where('states ilike ?', "%#{state}%")
+  def self.native_to(state_code)
+    where('states ilike ?', "%#{state_code}%")
   end
 
-  def self.search_name(name, state)
-    native_to(state).where('common_name ilike ? OR scientific_name ilike ?', "%#{name}%", "%#{name}%")
+  def self.search_name(name, state_code)
+    native_to(state_code).where('common_name ilike ? OR scientific_name ilike ?', "%#{name}%", "%#{name}%")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
-      resources :gardens, only: %i(index show) do
+      resources :gardens, only: %i(index show create destroy) do
         resources :plots, only: %i(index show create update destroy)
       end
       resources :plants, only: %i[index show]  

--- a/spec/models/plant_spec.rb
+++ b/spec/models/plant_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe Plant, type: :model do
 
         expect(Plant.native_to("VT")).to include(plant_1, plant_2)
         expect(Plant.native_to("VT")).not_to include(plant_3)
+        expect(Plant.native_to("NA")).to eq([])
       end
     end
 

--- a/spec/models/plant_spec.rb
+++ b/spec/models/plant_spec.rb
@@ -37,6 +37,12 @@ RSpec.describe Plant, type: :model do
         expect(Plant.search_name("hal", "VT")).to include(plant_1, plant_2)
         expect(Plant.search_name("hal", "VT")).not_to include(plant_3)
       end
+
+      it 'returns an empty array if no name matches' do
+        plants = create_list(:plant, 3)
+
+        expect(Plant.search_name('1$#', "VT")).to eq([])
+      end
     end
   end
 end

--- a/spec/models/plant_spec.rb
+++ b/spec/models/plant_spec.rb
@@ -18,9 +18,7 @@ RSpec.describe Plant, type: :model do
         expect(Plant.native_to("VT")).not_to include(plant_3)
       end
     end
-  end
 
-  describe 'instance methods' do
     describe '#search_name(name)' do
       it 'returns any plants matching a fragment of common name' do
         plant_1 = create(:plant, common_name: "Halo Bunny", states: "VT WA")

--- a/spec/models/plant_spec.rb
+++ b/spec/models/plant_spec.rb
@@ -7,16 +7,6 @@ RSpec.describe Plant, type: :model do
     it { should have_many(:plots).through(:plot_plants) }
   end
 
-  describe 'validations' do
-    it { should validate_presence_of(:usda_symbol) }
-    it { should validate_presence_of(:scientific_name) }
-    it { should validate_presence_of(:common_name) }
-    it { should validate_presence_of(:temperature_min) }
-    it { should validate_presence_of(:moisture_use) }
-
-    it { should validate_numericality_of(:temperature_min) }
-  end
-
   describe 'class methods' do
     describe '#native_to(state)' do
       it 'returns all plants native to provided state' do
@@ -26,6 +16,28 @@ RSpec.describe Plant, type: :model do
 
         expect(Plant.native_to("VT")).to include(plant_1, plant_2)
         expect(Plant.native_to("VT")).not_to include(plant_3)
+      end
+    end
+  end
+
+  describe 'instance methods' do
+    describe '#search_name(name)' do
+      it 'returns any plants matching a fragment of common name' do
+        plant_1 = create(:plant, common_name: "Halo Bunny", states: "VT WA")
+        plant_2 = create(:plant, common_name: "Hal Bunno", states: "VT WA")
+        plant_3 = create(:plant, common_name: "Squirrel", states: "VT WA")
+
+        expect(Plant.search_name("hal", "VT")).to include(plant_1, plant_2)
+        expect(Plant.search_name("hal", "VT")).not_to include(plant_3)
+      end
+
+      it 'also searches scientific name' do
+        plant_1 = create(:plant, common_name: "Halo Bunny", states: "VT WA")
+        plant_2 = create(:plant, scientific_name: "Hal Bunno", states: "VT WA")
+        plant_3 = create(:plant, common_name: "Squirrel", scientific_name: "Gary", states: "VT WA")
+
+        expect(Plant.search_name("hal", "VT")).to include(plant_1, plant_2)
+        expect(Plant.search_name("hal", "VT")).not_to include(plant_3)
       end
     end
   end

--- a/spec/requests/api/v1/gardens/delete_spec.rb
+++ b/spec/requests/api/v1/gardens/delete_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe 'gardens#delete' do
+  it 'deletes a garden and returns a 204 status' do
+    garden_1 = create :garden
+    garden_2 = create :garden
+    
+    expect(Garden.all).to include(garden_1)
+
+    delete "/api/v1/gardens/#{garden_1.id}"
+
+    expect(response).to be_successful
+    expect(response).to have_http_status(204)
+
+    expect(Garden.all).not_to include(garden_1)
+  end
+end

--- a/spec/requests/api/v1/gardens/delete_spec.rb
+++ b/spec/requests/api/v1/gardens/delete_spec.rb
@@ -14,4 +14,11 @@ RSpec.describe 'gardens#delete' do
 
     expect(Garden.all).not_to include(garden_1)
   end
+
+  it 'returns an error if garden cant be found' do
+    delete '/api/v1/gardens/9999999' do
+      expect(respone).not_to be_successful
+      expect(response).to have_http_status(400)
+    end
+  end
 end

--- a/spec/requests/api/v1/plants/index_spec.rb
+++ b/spec/requests/api/v1/plants/index_spec.rb
@@ -40,7 +40,33 @@ RSpec.describe '/api/v1/plants endpoints' do
 
     describe 'searching with additional parameters' do
       describe 'search_name' do
+        let!(:plant_1) { create(:plant, common_name: "Halo Bunny", scientific_name: "Fluffy Hal", states: "VT WA VA") }
+        let!(:plant_2) { create(:plant, common_name: "Halberd Flower", scientific_name: "Fluffy Halberd", states: "VT WA VA") }
+        let!(:plant_3) { create(:plant, common_name: "Squirrel's Tail", scientific_name: "Bunny Bun", states: "VT WA VA") }
 
+        it 'returns a json response with plants matching all or part of searched name' do
+          get '/api/v1/plants?state_code=VT&zip_code=05408&search_name=hal'
+
+          expect(response).to be_successful
+          expect(response).to have_http_status(200)
+
+          result = JSON.parse(response.body, symbolize_names: true)
+          expect(result).to have_key(:data)
+
+          expect(result[:data].count).to eq(2)
+        end
+
+        it 'if no plants match, returns an empty response with 200 status' do
+          get '/api/v1/plants?state_code=VT&zip_code=05408&search_name=x7f'
+
+          expect(response).to be_successful
+          expect(response).to have_http_status(200)
+
+          result = JSON.parse(response.body, symbolize_names: true)
+          expect(result).to have_key(:data)
+
+          expect(result[:data].count).to eq(0)
+        end
       end
     end
 

--- a/spec/requests/api/v1/plants/index_spec.rb
+++ b/spec/requests/api/v1/plants/index_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe '/api/v1/plants endpoints' do
   describe 'GET plants#index' do
     it 'returns a json response containing all plants native to queried state' do
       plants = create_list(:plant, 10, states: "VT CT VA WA")
-      get '/api/v1/plants?state=VT&zip_code=05408'
+      get '/api/v1/plants?state_code=VT&zip_code=05408'
 
       expect(response).to be_successful
       expect(response).to have_http_status(200)
@@ -38,9 +38,15 @@ RSpec.describe '/api/v1/plants endpoints' do
       expect(actual_first[:attributes]).to have_key(:precipitation_max)
     end
 
+    describe 'searching with additional parameters' do
+      describe 'search_name' do
+
+      end
+    end
+
     describe 'sad path: state missing or empty' do
       it 'returns an error' do
-        get '/api/v1/plants?state=&zip_code=05408'
+        get '/api/v1/plants?state_code=&zip_code=05408'
 
         expect(response).not_to be_successful
         expect(response).to have_http_status(400)
@@ -50,7 +56,7 @@ RSpec.describe '/api/v1/plants endpoints' do
         error_hash = result[:errors].first
         expect(error_hash).to have_key(:title)
         expect(error_hash).to have_key(:detail)
-        expect(error_hash[:detail]).to eq("State must be present")
+        expect(error_hash[:detail]).to be_a String
 
         get '/api/v1/plants?zip_code=05408'
         expect(response).not_to be_successful
@@ -60,7 +66,7 @@ RSpec.describe '/api/v1/plants endpoints' do
 
     describe 'sad path: zip_code missing or empty' do
       it 'returns an error' do
-        get '/api/v1/plants?state=VT'
+        get '/api/v1/plants?state_code=VT'
         expect(response).not_to be_successful
         expect(response).to have_http_status(400)
 
@@ -70,9 +76,9 @@ RSpec.describe '/api/v1/plants endpoints' do
         error_hash = result[:errors].first
         expect(error_hash).to have_key(:title)
         expect(error_hash).to have_key(:detail)
-        expect(error_hash[:detail]).to eq("Zip_code must be present")
+        expect(error_hash[:detail]).to be_a String
 
-        get '/api/v1/plants?state=VT&zip_code='
+        get '/api/v1/plants?state_code=VT&zip_code='
         expect(response).not_to be_successful
         expect(response).to have_http_status(400)
       end
@@ -91,7 +97,7 @@ RSpec.describe '/api/v1/plants endpoints' do
         error_hash = result[:errors].first
         expect(error_hash).to have_key(:title)
         expect(error_hash).to have_key(:detail)
-        expect(error_hash[:detail]).to eq("State must be present")
+        expect(error_hash[:detail]).to be_a String
       end
     end
   end


### PR DESCRIPTION
### User Story Implemented
#13 

### Describe Features Added/Changed
Plants can be searched by making the following request
get '/api/v1/plants?state_code=xx&zip_code=xxxxx&search_name=x'
This performs a case agnostic search on both common and scientific_name attributes for plants, returning a list of plants native to state that match. The search param is not required. If no plants match expect to receive a json response with [:data] key and value [] (empty array)

Also updated native_to(state) to make it case agnostic.

### Describe Tests Added/Changed
Happy and sad paths tested.

### Checklist before requesting a review
- [x] Added features have thorough tests written for their functionality?
- [x] All Tests Passing?
