### PR TITLE
implement low level caching with 12 hour expiration for weather forec…

### DIFF
--- a/app/services/location_service.rb
+++ b/app/services/location_service.rb
@@ -6,7 +6,9 @@ class LocationService
   end
 
   def self.get_lat_lon(zip_code)
-    response = conn.get("/v1/geocode/search?postcode=#{zip_code}&filter=countrycode:us")
-    JSON.parse(response.body, symbolize_names: true)
+    Rails.cache.fetch("zip - #{zip_code}", expires_in: 30.days) do
+      response = conn.get("/v1/geocode/search?postcode=#{zip_code}&filter=countrycode:us")
+      JSON.parse(response.body, symbolize_names: true)
+    end
   end
 end

--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -4,11 +4,13 @@ class WeatherService
   end
 
   def self.get_forecast(latitude, longitude)
-    url = conn.get("/points/#{latitude},#{longitude}")
-    url = conn.get(url.headers[:location]) if url.status == 301
-    forecast_url = JSON.parse(url.body, symbolize_names: true)
+    Rails.cache.fetch("forecast-#{latitude}-#{longitude}", expires_in: 12.hours) do
+      url = conn.get("/points/#{latitude},#{longitude}")
+      url = conn.get(url.headers[:location]) if url.status == 301
+      forecast_url = JSON.parse(url.body, symbolize_names: true)
 
-    response = conn.get("#{forecast_url[:properties][:forecast]}")
-    JSON.parse(response.body, symbolize_names: true)
+      response = conn.get("#{forecast_url[:properties][:forecast]}")
+      JSON.parse(response.body, symbolize_names: true)
+    end
   end
 end

--- a/app/services/weather_service.rb
+++ b/app/services/weather_service.rb
@@ -4,7 +4,7 @@ class WeatherService
   end
 
   def self.get_forecast(latitude, longitude)
-    Rails.cache.fetch("forecast-#{latitude}-#{longitude}", expires_in: 12.hours) do
+    Rails.cache.fetch("forecast-#{latitude}-#{longitude}", expires_in: 6.hours) do
       url = conn.get("/points/#{latitude},#{longitude}")
       url = conn.get(url.headers[:location]) if url.status == 301
       forecast_url = JSON.parse(url.body, symbolize_names: true)


### PR DESCRIPTION
This PR implements low level caching for weather forecasts, where a call to the WeatherService should now be cached for each unique latitude and longitude for 6 hours. This should protect to a certain degree from errors caused by rate limiting on the weather.gov api.

Caching also implemented on the location service, which is set to a 30 day expiry on the thinking that it shouldn't change much (or ever).

### Checklist before requesting a review
- [x] Added features have thorough tests written for their functionality?
- [x] All Tests Passing?
